### PR TITLE
Use regex to replace the "filename in line"

### DIFF
--- a/syntax_checkers/cpp/check.py
+++ b/syntax_checkers/cpp/check.py
@@ -5,6 +5,7 @@
 import locale
 import os
 import shlex
+import re
 import subprocess
 import sys
 
@@ -120,9 +121,10 @@ def main():
         errors = errors.decode(locale.getpreferredencoding())
 
     exit_status = 0
+    regex = re.compile('[/a-zA-Z0-9-<>.]+:[0-9]+:[0-9]+:[a-zA-Z ]+:.*')
 
     for line in errors.splitlines(True):
-        if filename in line or 'built-in' in line:
+        if re.search(regex, line):
             sys.stderr.write(line)
             exit_status = 1
 

--- a/syntax_checkers/cpp/check.py
+++ b/syntax_checkers/cpp/check.py
@@ -122,7 +122,7 @@ def main():
     exit_status = 0
 
     for line in errors.splitlines(True):
-        if filename in line:
+        if filename in line or 'built-in' in line:
             sys.stderr.write(line)
             exit_status = 1
 


### PR DESCRIPTION
Hi
I think this could be better.There can't always be errors with filename. Sometimes there may be some other situations, e.g. the complier can't find the config.h file.But syntastic-extras doesn't give a tip.It could be fixed by using regex.
Thanks for your work.
ssfdust