### PR TITLE
Improve a compile_commands.json support

### DIFF
--- a/test/bear_compile_commands/bad.cpp
+++ b/test/bear_compile_commands/bad.cpp
@@ -1,0 +1,3 @@
+#include "some_header.h"
+
+1 /

--- a/test/bear_compile_commands/build/compile_commands.json
+++ b/test/bear_compile_commands/build/compile_commands.json
@@ -1,0 +1,36 @@
+[
+{
+  "directory": "/Users/myint/projects/perceptualdiff/build",
+  "arguments": [
+      "c++",
+      "-Werror",
+      "-DDEFINED",
+      "-DCONFIG_VALUE=42",
+      "-isystem",
+      "test/bear_compile_commands/header_directory",
+      "-nostdinc++",
+      "-o",
+      "ignore_this.o",
+      "-c",
+      "test/bear_compile_commands/good.cpp"
+  ],
+  "file": "test/bear_compile_commands/good.cpp"
+},
+{
+  "directory": "/Users/myint/projects/perceptualdiff/build",
+  "arguments": [
+      "c++",
+      "-Werror",
+      "-DDEFINED",
+      "-DCONFIG_VALUE=42",
+      "-isystem",
+      "test/bear_compile_commands/header_directory",
+      "-nostdinc++",
+      "-o",
+      "ignore_this.o",
+      "-c",
+      "test/bear_compile_commands/bad.cpp"
+  ],
+  "file": "test/bear_compile_commands/bad.cpp"
+}
+]

--- a/test/bear_compile_commands/good.cpp
+++ b/test/bear_compile_commands/good.cpp
@@ -1,0 +1,1 @@
+#include "some_header.h"

--- a/test/compile_commands/build/compile_commands.json
+++ b/test/compile_commands/build/compile_commands.json
@@ -1,12 +1,12 @@
 [
 {
   "directory": "/Users/myint/projects/perceptualdiff/build",
-  "command": "c++ -isystem test/compile_commands/header_directory -o ignore_this.o -c test/compile_commands/good.cpp",
+  "command": "c++ -Werror -DDEFINED -DCONFIG_VALUE=42 -isystem test/compile_commands/header_directory -nostdinc++ -o ignore_this.o -c test/compile_commands/good.cpp",
   "file": "test/compile_commands/good.cpp"
 },
 {
   "directory": "/Users/myint/projects/perceptualdiff/build",
-  "command": "c++ -isystem test/compile_commands/header_directory -o ignore_this.o -c test/compile_commands/bad.cpp",
+  "command": "c++ -Werror -DDEFINED -DCONFIG_VALUE=42 -isystem test/compile_commands/header_directory -nostdinc++ -o ignore_this.o -c test/compile_commands/bad.cpp",
   "file": "test/compile_commands/bad.cpp"
 }
 ]

--- a/test/test.bash
+++ b/test/test.bash
@@ -88,6 +88,10 @@ python ./syntax_checkers/cpp/test.py test/compile_commands/good.cpp
 python ./syntax_checkers/cpp/test.py test/compile_commands/bad.cpp 2>&1 \
     | grep 'test/compile_commands/bad.cpp:3' > /dev/null
 
+python ./syntax_checkers/cpp/test.py test/bear_compile_commands/good.cpp
+python ./syntax_checkers/cpp/test.py test/bear_compile_commands/bad.cpp 2>&1 \
+    | grep 'test/bear_compile_commands/bad.cpp:3' > /dev/null
+
 # With `CC` or `CXX` composed of multiple arguments.
 CC='echo hello world' \
     "$PYTHON" ./syntax_checkers/cpp/test.py test/syntastic_config/good.c \


### PR DESCRIPTION
* Parse file generated by `bear`.
* Filter all irrelevant compile options out to allow syntax checking
  in case of cross-compiled projects.